### PR TITLE
Cleaned up some code:

### DIFF
--- a/src/BlazorSortableJS.DemoCSB/Program.cs
+++ b/src/BlazorSortableJS.DemoCSB/Program.cs
@@ -6,7 +6,6 @@ namespace BlazorSortableJS.Demo
     {
         public static void Main(string[] args)
         {
-
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/src/BlazorSortableJS/SortableJS.cs
+++ b/src/BlazorSortableJS/SortableJS.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.JSInterop;
-using Microsoft.AspNetCore.Components;
 using System.Linq;
 using System.Text.Json;
 using System.Reflection;
@@ -12,33 +10,31 @@ namespace BlazorSortableJS
 {
     public class SortableJS<T> : IAsyncDisposable
     {
-        private readonly IJSRuntime _jSRuntime;
-        private SortableJsOptions _opt { get; set; }
+        public Guid RefId { get; private set; } = Guid.NewGuid();
         public EventHandler OnDataSet { get; set; }
-        private Guid _refId { get; set; }
 
-        public Guid RefId
-        {
-            get { return _refId;}
-        }
-        private string _elId { get; set; }
-        private List<SortableJSSortItem<T>> _list { get; set; } = new List<SortableJSSortItem<T>>();
+        private readonly IJSRuntime _jSRuntime;
+        private readonly List<SortableJSSortItem<T>> _list = new List<SortableJSSortItem<T>>();
 
-        public List<SortableJSSortItem<T>> GetRaw()
-        {
-            return _list.Where(q => q.Show == true).ToList();
-        }
+        private SortableJsOptions _opt;
+        private string _elId;
 
         public SortableJS(IJSRuntime jsRuntime)
         {
-            _refId = Guid.NewGuid();
             _jSRuntime = jsRuntime;
         }
-        public async ValueTask<object> Create(string elId, SortableJsOptions opt)
+
+        public List<SortableJSSortItem<T>> GetRaw()
+        {
+            return _list.Where(q => q.Show).ToList();
+        }
+
+        public async ValueTask<object> CreateAsync(string elId, SortableJsOptions opt)
         {
             _opt = opt;
             _elId = elId;
-            await _jSRuntime.InvokeAsync<object>("BlazorSortableJS.Create", _refId, elId, opt.RemoveNulls());
+
+            await _jSRuntime.InvokeAsync<object>("BlazorSortableJS.Create", RefId, elId, opt.RemoveNulls());
 
             //Register to all Events
             SortableJSEventHandler.OnChooseEvent += OnChoose;
@@ -53,26 +49,36 @@ namespace BlazorSortableJS
             SortableJSEventHandler.OnMoveEvent += OnMove;
             SortableJSEventHandler.OnCloneEvent += OnClone;
             SortableJSEventHandler.OnChangeEvent += OnChange;
+
             return default;
         }
-        public void SetData(List<T> list)
+
+        public void SetData(IEnumerable<T> list)
         {
             foreach (var item in list)
             {
-                _list.Add(new SortableJSSortItem<T>() { Data = item, DataId = Guid.NewGuid().ToString() });
+                _list.Add(new SortableJSSortItem<T>()
+                {
+                    Data = item,
+                    DataId = Guid.NewGuid().ToString()
+                });
             }
+
             OnDataSet?.Invoke(new object(), new EventArgs());
         }
+
         public async Task ClearAsync()
         {
-            await Distroy();
+            await DestroyAsync();
             _list.Clear();
         }
-        public void UpdateProperty(string id, string propertyName, object value )
+
+        public void UpdateProperty(string id, string propertyName, object value)
         {
-            var data = _list.FirstOrDefault(q => q.DataId == id);
+            var data = _list.Find(q => q.DataId == id);
             SetValue(data.Data, propertyName, value);
         }
+
         private void SetValue(object obj, string propertyName, object value)
         {
             Type type = typeof(T);
@@ -83,34 +89,38 @@ namespace BlazorSortableJS
 
         public async Task AddItemAsync(T model)
         {
-            await Distroy();
-                _list.Add(new SortableJSSortItem<T>() { Data = model, DataId = Guid.NewGuid().ToString() });
+            await DestroyAsync();
+            _list.Add(new SortableJSSortItem<T>() { Data = model, DataId = Guid.NewGuid().ToString() });
         }
+
         public async Task RemoveItemAsync(string id)
         {
-            await Distroy();
+            await DestroyAsync();
             var item = _list.FirstOrDefault(q => q.DataId == id);
             if (item != null)
             {
                 _list.Remove(item);
             }
         }
+
         public async Task ResyncAsync()
         {
-            await Create(_elId, _opt);
+            await CreateAsync(_elId, _opt);
         }
+
         public void Update(string id, T model)
         {
-            var data = _list.FirstOrDefault(q => q.DataId == id);
+            var data = _list.Find(q => q.DataId == id);
+
             if (data == null)
                 return;
 
             data.Data = model;
         }
-        public async Task<List<T>> GetData()
-        {
 
-            var indexs = await ToArray() ;
+        public async Task<List<T>> GetDataAsync()
+        {
+            var indexs = await ToArrayAsync();
             //var order = indexs.ToList();
             //var temp = order.Select(i => _list[i]).ToList();
             var result = new List<T>();
@@ -121,26 +131,144 @@ namespace BlazorSortableJS
             return result;
         }
 
-        public ValueTask<object> Sort(string[] order)
+        public ValueTask<object> SortAsync(string[] order)
         {
-        if(_refId == default) throw new InvalidOperationException("Create Function must be called first");
-            return _jSRuntime.InvokeAsync<object>("BlazorSortableJS.Sort", _refId, order);
+            if (RefId == default)
+            {
+                throw new InvalidOperationException("Create Function must be called first");
+            }
+
+            return _jSRuntime.InvokeAsync<object>("BlazorSortableJS.Sort", RefId, order);
         }
-        public ValueTask<string[]> ToArray()
+
+        public ValueTask<string[]> ToArrayAsync()
         {
-            if (_refId == default) throw new InvalidOperationException("Create Function must be called first");
-            return _jSRuntime.InvokeAsync<string[]>("BlazorSortableJS.ToArray", _refId);
+            if (RefId == default)
+            {
+                throw new InvalidOperationException("Create Function must be called first");
+            }
+
+            return _jSRuntime.InvokeAsync<string[]>("BlazorSortableJS.ToArray", RefId);
         }
-        public ValueTask<object> Distroy()
+
+        public ValueTask<object> DestroyAsync()
         {
-            if (_refId == default) throw new InvalidOperationException("Create Function must be called first");
-            return _jSRuntime.InvokeAsync<object>("BlazorSortableJS.Destroy", _refId);
+            if (RefId == default)
+            {
+                throw new InvalidOperationException("Create Function must be called first");
+            }
+
+            return _jSRuntime.InvokeAsync<object>("BlazorSortableJS.Destroy", RefId);
         }
+
         public void Add(string dataId, string data)
         {
             var newItem = JsonSerializer.Deserialize<T>(data);
-            _list.Add(new SortableJSSortItem<T>() { DataId = dataId, Data = newItem, Show = false});
+            _list.Add(new SortableJSSortItem<T>() { DataId = dataId, Data = newItem, Show = false });
         }
+
+        public void OnChoose(object sender, SortableJSEvent data)
+        {
+            if (Guid.Parse(sender.ToString()) == RefId)
+            {
+                _jSRuntime?.InvokeAsync<object>("BlazorSortableJS.SetChoiceItem", RefId, _list.First(q => q.DataId == data.DataId).Data);
+                _opt.OnChoose?.Invoke(data);
+            }
+        }
+
+        public void OnUnchoose(object sender, SortableJSEvent data)
+        {
+            if (Guid.Parse(sender.ToString()) == RefId)
+            {
+                _opt.OnUnchoose?.Invoke(data);
+            }
+        }
+
+        public void OnStart(object sender, SortableJSEvent data)
+        {
+            if (Guid.Parse(sender.ToString()) == RefId)
+            {
+                _opt.OnStart?.Invoke(data);
+            }
+        }
+
+        public void OnEnd(object sender, SortableJSEvent data)
+        {
+            if (Guid.Parse(sender.ToString()) == RefId)
+            {
+                _opt.OnEnd?.Invoke(data);
+            }
+        }
+
+        public void OnAdd(object sender, SortableJSEvent data)
+        {
+            if (Guid.Parse(sender.ToString()) == RefId)
+            {
+                var json = JsonSerializer.Serialize(data.Data);
+                Add(data.DataId, json);
+
+                _opt.OnAdd?.Invoke(data);
+            }
+        }
+
+        public void OnUpdate(object sender, SortableJSEvent data)
+        {
+            if (Guid.Parse(sender.ToString()) == RefId)
+            {
+                _opt.OnUpdate?.Invoke(data);
+            }
+        }
+
+        public void OnSort(object sender, SortableJSEvent data)
+        {
+            if (Guid.Parse(sender.ToString()) == RefId)
+            {
+                _opt.OnSort?.Invoke(data);
+            }
+        }
+
+        public void OnRemove(object sender, SortableJSEvent data)
+        {
+            // DO NOT remove items from _list here. SortableJS will remove the index
+            // GetDataAsync will only return the indices SortableJS provides it.
+            if (Guid.Parse(sender.ToString()) == RefId)
+            {
+                _opt.OnRemove?.Invoke(data);
+            }
+        }
+
+        public void OnFilter(object sender, SortableJSEvent data)
+        {
+            if (Guid.Parse(sender.ToString()) == RefId)
+            {
+                _opt.OnFilter?.Invoke(data);
+            }
+        }
+
+        public void OnMove(object sender, SortableJSEvent data)
+        {
+            if (Guid.Parse(sender.ToString()) == RefId)
+            {
+                _opt.OnMove?.Invoke(data);
+            }
+        }
+
+        public void OnClone(object sender, SortableJSEvent data)
+        {
+            if (Guid.Parse(sender.ToString()) == RefId)
+            {
+                _opt.OnClone?.Invoke(data);
+            }
+        }
+
+        public void OnChange(object sender, SortableJSEvent data)
+        {
+            if (Guid.Parse(sender.ToString()) == RefId)
+            {
+                _opt.OnChange?.Invoke(data);
+            }
+        }
+
         public void Dispose()
         {
             SortableJSEventHandler.OnChooseEvent -= OnChoose;
@@ -157,79 +285,9 @@ namespace BlazorSortableJS
             SortableJSEventHandler.OnChangeEvent -= OnChange;
         }
 
-        public void OnChoose(object sender, SortableJSEvent data)
-        {
-            if (Guid.Parse(sender.ToString()) != _refId) return;
-            _jSRuntime?.InvokeAsync<object>("BlazorSortableJS.SetChoiceItem", _refId, _list.First(q => q.DataId == data.DataId).Data);
-            _opt.OnChoose?.Invoke(data);
-            Console.WriteLine(data.DataId);
-        }
-        public void OnUnchoose(object sender, SortableJSEvent data)
-        {
-            if (Guid.Parse(sender.ToString()) != _refId) return;
-            _opt.OnUnchoose?.Invoke(data);
-        }
-        public void OnStart(object sender, SortableJSEvent data)
-        {
-            if (Guid.Parse(sender.ToString()) != _refId) return;
-            _opt.OnStart?.Invoke(data);
-        }
-        public void OnEnd(object sender, SortableJSEvent data)
-        {
-            if (Guid.Parse(sender.ToString()) != _refId) return;
-            _opt.OnEnd?.Invoke(data);
-        }
-        public void OnAdd(object sender, SortableJSEvent data)
-        {
-            if (Guid.Parse(sender.ToString()) != _refId) return;
-            var json = JsonSerializer.Serialize(data.Data);
-            Add(data.DataId,json);
-         
-            _opt.OnAdd?.Invoke(data);
-        }
-        public void OnUpdate(object sender, SortableJSEvent data)
-        {
-            if (Guid.Parse(sender.ToString()) != _refId) return;
-            _opt.OnUpdate?.Invoke(data);
-        }
-        public void OnSort(object sender, SortableJSEvent data)
-        {
-            if (Guid.Parse(sender.ToString()) != _refId) return;
-            _opt.OnSort?.Invoke(data);
-        }
-
-        public void OnRemove(object sender, SortableJSEvent data)
-        {
-            // DO NOT remove items from _list here. SortableJS will remove the index
-            // Getdata will only return the indexs SortableJS provides it.
-            if (Guid.Parse(sender.ToString()) != _refId) return;
-            _opt.OnRemove?.Invoke(data);
-
-        }
-        public void OnFilter(object sender, SortableJSEvent data)
-        {
-            if (Guid.Parse(sender.ToString()) != _refId) return;
-            _opt.OnFilter?.Invoke(data);
-        }
-        public void OnMove(object sender, SortableJSEvent data)
-        {
-            if (Guid.Parse(sender.ToString()) != _refId) return;
-            _opt.OnMove?.Invoke(data);
-        }
-        public void OnClone(object sender, SortableJSEvent data)
-        {
-            if (Guid.Parse(sender.ToString()) != _refId) return;
-            _opt.OnClone?.Invoke(data);
-        }
-        public void OnChange(object sender, SortableJSEvent data)
-        {
-            if (Guid.Parse(sender.ToString()) != _refId) return;
-            _opt.OnChange?.Invoke(data);
-        }
-
         public async ValueTask DisposeAsync()
         {
-            await Distroy();
+            await DestroyAsync();
             Dispose();
         }
     }

--- a/src/BlazorSortableJS/SortableJSEventHandler.cs
+++ b/src/BlazorSortableJS/SortableJSEventHandler.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using Microsoft.JSInterop;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
-using System.Reflection;
 
 namespace BlazorSortableJS
 {
     public static class SortableJSEventHandler
     {
-      
         public static EventHandler<SortableJSEvent> OnChooseEvent { get; set; }
         public static EventHandler<SortableJSEvent> OnUnchooseEvent { get; set; }
         public static EventHandler<SortableJSEvent> OnStartEvent { get; set; }
@@ -29,72 +25,82 @@ namespace BlazorSortableJS
             OnChooseEvent?.Invoke(data.RefId, data);
             return default;
         }
+
         [JSInvokable]
         public static Task OnUnchoose(SortableJSEvent data)
         {
             OnUnchooseEvent?.Invoke(data.RefId, data);
             return default;
         }
+
         [JSInvokable]
         public static Task OnStart(SortableJSEvent data)
         {
             OnStartEvent?.Invoke(data.RefId, data);
             return default;
         }
+
         [JSInvokable]
         public static Task OnEnd(SortableJSEvent data)
         {
             OnEndEvent?.Invoke(data.RefId, data);
             return default;
         }
+
         [JSInvokable]
         public static Task OnAdd(SortableJSEvent data)
         {
             OnAddEvent?.Invoke(data.RefId, data);
             return default;
         }
+
         [JSInvokable]
         public static Task OnUpdate(SortableJSEvent data)
         {
             OnUpdateEvent?.Invoke(data.RefId, data);
             return default;
         }
+
         [JSInvokable]
         public static Task OnSort(SortableJSEvent data)
         {
             OnSortEvent?.Invoke(data.RefId, data);
             return default;
         }
+
         [JSInvokable]
         public static Task OnRemove(SortableJSEvent data)
         {
             OnRemoveEvent?.Invoke(data.RefId, data);
             return default;
         }
+
         [JSInvokable]
         public static Task OnFilter(SortableJSEvent data)
         {
             OnFilterEvent?.Invoke(data.RefId, data);
             return default;
         }
+
         [JSInvokable]
         public static Task OnMove(SortableJSEvent data)
         {
             OnMoveEvent?.Invoke(data.RefId, data);
             return default;
         }
+
         [JSInvokable]
         public static Task OnClone(SortableJSEvent data)
         {
             OnCloneEvent?.Invoke(data.RefId, data);
             return default;
         }
+
         [JSInvokable]
         public static Task OnChange(SortableJSEvent data)
         {
             OnChangeEvent?.Invoke(data.RefId, data);
             return default;
         }
-
     }
 }

--- a/src/BlazorSortableJS/SortableJSSortItem.cs
+++ b/src/BlazorSortableJS/SortableJSSortItem.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-// For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
-
 namespace BlazorSortableJS
 {
     public class SortableJSSortItem<T>
@@ -12,5 +10,5 @@ namespace BlazorSortableJS
         public string DataId { get; set; }
         public bool Show { get; set; } = true;
         public T Data { get; set; }
-}
+    }
 }

--- a/src/BlazorSortableJS/SortableJsOptions.cs
+++ b/src/BlazorSortableJS/SortableJsOptions.cs
@@ -1,55 +1,43 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Dynamic;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BlazorSortableJS
 {
     public class SortableJsOptions
     {
+        public string Group { get; set; }
+        public bool? Sort { get; set; }
+        public bool? Disabled { get; set; }
+        public string Handle { get; set; }
+        public string Draggable { get; set; }
+        public int? SwapThreshold { get; set; }
+        public bool? InvertSwap { get; set; }
+        public int? InvertedSwapThreshold { get; set; }
+        public int? Delay { get; set; }
+        public bool? DelayOnTouchOnly { get; set; }
+        public int? TouchStartThreshold { get; set; }
+        public bool? RemoveCloneOnHide { get; set; }
+        public string Direction { get; set; }
+        public string GhostClass { get; set; }
+        public string ChosenClass { get; set; }
+        public string DragClass { get; set; }
+        public string Filter { get; set; }
+        public bool? PreventOnFilter { get; set; }
 
-        public string group { get; set; }
-        public bool? sort { get; set; }
-        public bool? disabled { get; set; } 
-        public string handle { get; set; }
-        public string draggable { get; set; }
-        public int? swapThreshold { get; set; }  
-        public bool? invertSwap { get; set; }  
-        public int? invertedSwapThreshold { get; set; } 
-        public int? delay { get; set; } 
-        public bool? delayOnTouchOnly { get; set; } 
-        public int? touchStartThreshold { get; set; } 
-        public bool? removeCloneOnHide { get; set; } 
-        public string direction { get; set; }
-        public string ghostClass { get; set; } 
-        public string chosenClass { get; set; } 
-        public string dragClass { get; set; } 
-        public string filter { get; set; }
-        public bool? preventOnFilter { get; set; }
+        public double? Animation { get; set; }
+        public string Easing { get; set; }
 
-        //  store: null,  // @see Store
-        public double? animation { get; set; }
-        public string easing { get; set; }
+        public string DataIdAttr { get; set; }
+        public bool? ForceFallback { get; set; }
 
-        public string dataIdAttr { get; set; } 
-        public bool? forceFallback { get; set; } 
+        public string FallbackClass { get; set; }
+        public bool? FallbackOnBody { get; set; }
+        public int? FallbackTolerance { get; set; }
 
-        public string fallbackClass { get; set; }
-        public bool? fallbackOnBody { get; set; } 
-        public int? fallbackTolerance { get; set; } 
+        public bool? DragoverBubble { get; set; }
 
-        public bool? dragoverBubble { get; set; } 
-        
-        public int? emptyInsertThreshold { get; set; } 
+        public int? EmptyInsertThreshold { get; set; }
 
-
-        //setData: function(/** DataTransfer */dataTransfer, /** HTMLElement*/dragEl) {
-
-        //dataTransfer.setData('Text', dragEl.textContent); // `dataTransfer` object of HTML5 DragEvent
-        //},
-
-        // Element is chosen
         public Action<SortableJSEvent> OnChoose { get; set; }
         public Action<SortableJSEvent> OnUnchoose { get; set; }
         public Action<SortableJSEvent> OnStart { get; set; }
@@ -70,26 +58,19 @@ namespace BlazorSortableJS
         {
             var t = fixMe.GetType();
             var returnClass = new Dictionary<string, object>();
+
             foreach (var pr in t.GetProperties())
             {
                 var val = pr.GetValue(fixMe);
-                if(pr.PropertyType == typeof(Action<SortableJSEvent>))
-                {
-
-                }
-                else if (val is string && string.IsNullOrWhiteSpace(val.ToString()))
-                {
-                }
-                else if (val == null)
-                {
-                }
-                else
+                if (pr.PropertyType != typeof(Action<SortableJSEvent>)
+                    && val != null
+                    && !string.IsNullOrWhiteSpace(val.ToString()))
                 {
                     returnClass.Add(pr.Name, val);
                 }
             }
+
             return returnClass;
         }
     }
-
 }


### PR DESCRIPTION
    Naming/Codestyle rules:
        Async-Methods should always have the Async-Suffix
        Properties should begin with an uppercase letter
        If-statements should always have curly braces
        Private Properties can be replaced with fields if the getter and setter do not add logic
        Fixed a bunch of typos like Distroy->Destroy
        Commented out code blocks that serve no purpose were deleted
    Optimizations:
        Linq queries can be optimized by replacing FirstOrDefault with Find
        Empty if-statements are redundant and can be replaced with one inverted if
        Properties can be assigned directly, so no need to do it in the constructor
        bool == true is redundant
        When a function only wants to enumerate something don't force others to pass a List<T>; use Enumerable<T> instead (list will still work but so will Arrays, etc.)