### PR TITLE
Support drag handle class

### DIFF
--- a/src/BlazorSortableJS.DemoCore/Pages/Index.razor
+++ b/src/BlazorSortableJS.DemoCore/Pages/Index.razor
@@ -6,9 +6,9 @@
 </button><div class="row">
     <div class="col-6">Sortable List
         
-            <SortGroup Items="items" Id="@Id1" Class="list-group" TemplateClass="list-group-item" @ref="                    MyGroup" TItem="Items" GroupName="test" OnAdd="OnAdd" OnSort="OnSort" OnRemove="OnRemove">
+            <SortGroup Items="items" Id="@Id1" Class="list-group" TemplateClass="list-group-item" @ref="MyGroup" TItem="Items" GroupName="test" OnAdd="OnAdd" OnSort="OnSort" OnRemove="OnRemove" Handle=".my-handle">
                 <Template Context="test">
-                    @test.Data.Text - @test.Data.Id
+                    <span class="oi oi-move my-handle"></span> @test.Data.Text - @test.Data.Id
                 </Template>
             </SortGroup>
         

--- a/src/BlazorSortableJS/Components/SortGroup.razor.cs
+++ b/src/BlazorSortableJS/Components/SortGroup.razor.cs
@@ -16,6 +16,7 @@ namespace BlazorSortableJS.Components
         [Parameter] public string Class { get; set; }
         [Parameter] public string TemplateClass { get; set; }
         [Parameter] public string GroupName { get; set; } = Guid.NewGuid().ToString();
+        [Parameter] public string Handle { get; set; }
         [Parameter] public string Style { get; set; }
         [Parameter] public bool IsDiv { get; set; }
         [Parameter] public RenderFragment<SortableJSSortItem<TItem>> Template { get; set; }
@@ -141,6 +142,7 @@ namespace BlazorSortableJS.Components
             await Sortable.CreateAsync(Id, new SortableJsOptions
             {
                 Group = GroupName,
+                Handle = Handle,
                 Animation = 100,
                 OnClone = OnCloneEvent,
                 OnAdd = OnAddEvent,


### PR DESCRIPTION
This PR just surfaces the sortablejs' "handle" option to the SortGroup component's public parameters so that it's possible to drag via a nested icon rather than anywhere in the template.

Would it be possible to merge this @jbomhold3 and get a quick release?  I updated the Index.razor just to show it being used but let me know if you don't want that to be changed.